### PR TITLE
Randomize initial song in aboutme music player

### DIFF
--- a/aboutme/js/music-player.js
+++ b/aboutme/js/music-player.js
@@ -62,7 +62,8 @@
 
         if (playlist.length > 0 && elPlayer) {
           elPlayer.style.display = '';
-          loadTrack(0, false);
+          var randomStartIndex = Math.floor(Math.random() * playlist.length);
+          loadTrack(randomStartIndex, false);
         } else if (elPlayer) {
           elPlayer.style.display = 'none';
         }


### PR DESCRIPTION
### Motivation
- Start playback from a random song on the aboutme subsite while keeping subsequent playback sequential through the existing playlist.

### Description
- In `aboutme/js/music-player.js` replace the fixed start `loadTrack(0, false)` with a randomly computed index using `var randomStartIndex = Math.floor(Math.random() * playlist.length);` and call `loadTrack(randomStartIndex, false)`.

### Testing
- Ran `node --check aboutme/js/music-player.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee141323e4832e843c348f4210b869)